### PR TITLE
Fix drawOrder loading values

### DIFF
--- a/spinehaxe/SkeletonJson.hx
+++ b/spinehaxe/SkeletonJson.hx
@@ -480,14 +480,13 @@ class SkeletonJson {
 			}
 		}
 
-		var drawOrderValues:JsonNode = map.getNode("drawOrder");
+		var drawOrderValues:Array<{slot:String, offset: Int}> = map.getNode("drawOrder");
 		if (drawOrderValues == null) drawOrderValues = map.getNode("draworder");
 		if (drawOrderValues != null && drawOrderValues.length > 0) {
 			var drawOrderTimeline:DrawOrderTimeline = new DrawOrderTimeline(drawOrderValues.length);
 			var slotCount:Int = skeletonData.slots.length;
 			frameIndex = 0;
-			for (drawOrderValue in drawOrderValues.fields()) {
-				var drawOrderMap = drawOrderValues.getNode(drawOrderValue);
+			for (drawOrderMap in drawOrderValues) {
 				var drawOrder:Vector<Int> = null;
 				if (drawOrderMap.hasOwnProperty("offsets")) {
 					drawOrder = new Vector<Int>(slotCount);


### PR DESCRIPTION
Currently, the drawOrder loader completely misloads draworder changes (create a animation that changes the draworder and see for yourself).
This happens because the original drawOrderValues is a list and (at least on my version of Haxe), the dynamic object from Json behaves as one and therefore the `fields()` function returns `length` and `__s`.
Try to `trace(drawOrderValue)` to see what I mean.
