### PR TITLE
truncate added polygon's vertices

### DIFF
--- a/spinehaxe/SkeletonBounds.hx
+++ b/spinehaxe/SkeletonBounds.hx
@@ -77,6 +77,7 @@ class SkeletonBounds {
 			else polygon = new Polygon();
 
 			polygons.push(polygon);
+			polygon.vertices.splice(boundingBox.vertices.length, polygon.vertices.length - boundingBox.vertices.length);
 			boundingBox.computeWorldVertices(x, y, slot.bone, polygon.vertices);
 		}
 		if (updateAabb)


### PR DESCRIPTION
in SkeletonBounds.hx:
Truncate polygon vertices that are added in the process. Missing code from libgdx and AS3 runtimes solves the problem. See issue #19.