### PR TITLE
EventTimeline, firedEvents : binary search parameters issue

### DIFF
--- a/spinehaxe/animation/EventTimeline.hx
+++ b/spinehaxe/animation/EventTimeline.hx
@@ -74,7 +74,7 @@ class EventTimeline implements Timeline {
 		if (lastTime < frames[0])
 			frameIndex = 0;
 		else {
-			frameIndex = Animation.binarySearch1(frames, time) - 1;
+			frameIndex = Animation.binarySearch1(frames, lastTime);
 			var frame:Float = frames[frameIndex];
 			while(frameIndex > 0) {
 				// Fire multiple events with the same frame.


### PR DESCRIPTION
Hi,

Using multiple events on a single animation I found that the same events were fired multiple times, on each frame following the event.

I checked the code, found nothing at first view, went to the Esoteric forum where someone told me the events are not intented to be fired multiple times.

I looked further in the spinehaxe code and found the bug. The fact is that it worked well with a single event, but not with many.

JAVA
https://github.com/EsotericSoftware/spine-runtimes/blob/master/spine-libgdx/spine-libgdx/src/com/esotericsoftware/spine/Animation.java#L568
> frameIndex = binarySearch(frames, lastTime);

AS3
https://github.com/EsotericSoftware/spine-runtimes/blob/master/spine-as3/spine-as3/src/spine/animation/EventTimeline.as#L71
> frameIndex = Animation.binarySearch1(frames, lastTime);

SpineHaxe
https://github.com/bendmorris/spinehaxe/blob/master/spinehaxe/animation/EventTimeline.hx#L77
> frameIndex = Animation.binarySearch1(frames, time) - 1;

Everything works now well with one or many events.