### PR TITLE
fix for SkeletonSprite with renderMeshes = false and skeleton.flipX = true

### DIFF
--- a/spinehaxe/platform/openfl/SkeletonSprite.hx
+++ b/spinehaxe/platform/openfl/SkeletonSprite.hx
@@ -209,7 +209,10 @@ class SkeletonSprite extends Sprite {
 
 				wrapper.x = bone.worldX;
 				wrapper.y = bone.worldY;
-				wrapper.rotation = bone.worldRotationX * flipX * flipY;
+				
+				wrapper.rotation = bone.worldRotationX;
+				if (skeleton.flipX) wrapper.rotation += 180;
+				
 				wrapper.scaleX = bone.worldScaleX * flipX;
 				wrapper.scaleY = bone.worldScaleY * flipY;
 				addChild(wrapper);


### PR DESCRIPTION
This change will fix spineboy demo provided with the lib.
As you can see for yourself the demo is broken if you set `skeleton.flipX = false` (while renderMeshes is false also)