### PR TITLE
Fix RegionAttachment compilation with Haxe 4, closes #33

### DIFF
--- a/spinehaxe/attachments/RegionAttachment.hx
+++ b/spinehaxe/attachments/RegionAttachment.hx
@@ -33,7 +33,7 @@ package spinehaxe.attachments;
 import spinehaxe.Bone;
 import haxe.ds.Vector;
 
-class RegionAttachment extends Attachment #if (haxe_ver >= "4.0.0") implements Dynamic<Dynamic> #end {
+class RegionAttachment extends Attachment #if (haxe_ver < "4.0.0") implements Dynamic<Dynamic> #end {
 	public static inline var X1:Int = 0;
 	public static inline var Y1:Int = 1;
 	public static inline var X2:Int = 2;

--- a/spinehaxe/attachments/RegionAttachment.hx
+++ b/spinehaxe/attachments/RegionAttachment.hx
@@ -33,7 +33,7 @@ package spinehaxe.attachments;
 import spinehaxe.Bone;
 import haxe.ds.Vector;
 
-class RegionAttachment extends Attachment implements Dynamic<Dynamic> {
+class RegionAttachment extends Attachment #if (haxe_ver >= "4.0.0") implements Dynamic<Dynamic> #end {
 	public static inline var X1:Int = 0;
 	public static inline var Y1:Int = 1;
 	public static inline var X2:Int = 2;


### PR DESCRIPTION
This is obviously not backwards compatible, but at least makes things compile with Haxe 4 for now. Not sure if you'd want to emulate the functionality long-term [like OpenFL did in some cases](https://github.com/HaxeFoundation/haxe/issues/6191#issuecomment-391804238), but that strikes me as quite ugly.

I've made sure Flixel doesn't rely on this any longer, leads to nicer code anyway: https://github.com/HaxeFlixel/flixel-addons/commit/a882febcc59ba1e0a2b2a501f1bc7856a064c596?w=1