### PR TITLE
Fix Std.is() deprecation warnings with Haxe 4.2

### DIFF
--- a/spinehaxe/Pool.hx
+++ b/spinehaxe/Pool.hx
@@ -43,7 +43,7 @@ package spinehaxe;
 	}
 	
 	public function free(item:T):Void {
-		if (Std.is(item, Poolable)) cast(item, Poolable).reset();
+		if ((item is Poolable)) cast(item, Poolable).reset();
 		items.push(item);
 	}
 	

--- a/spinehaxe/Skeleton.hx
+++ b/spinehaxe/Skeleton.hx
@@ -183,7 +183,7 @@ class Skeleton {
 			sortPathConstraintAttachment(data.skins[ii], slotIndex, slotBone);
 
 		var attachment:Attachment = slot.attachment;
-		if (Std.is(attachment, PathAttachment)) sortPathConstraintAttachment2(attachment, slotBone);
+		if ((attachment is PathAttachment)) sortPathConstraintAttachment2(attachment, slotBone);
 
 		var constrained:Array<Bone> = constraint.bones;
 		var boneCount:Int = constrained.length;

--- a/spinehaxe/SkeletonJson.hx
+++ b/spinehaxe/SkeletonJson.hx
@@ -700,9 +700,9 @@ class SkeletonJson {
 	static private function readCurve(map:JsonNode, timeline:CurveTimeline, frameIndex:Int) : Void {
 		var curve:Dynamic = map.getDynamic("curve");
 		if (curve == null) return;
-		if (Std.is(curve, String) && cast(curve, String) == "stepped")
+		if ((curve is String) && cast(curve, String) == "stepped")
 			timeline.setStepped(frameIndex);
-		else if (Std.is(curve, Array)) {
+		else if ((curve is Array)) {
 			var curveValues:Array<Float> = cast curve;
 			timeline.setCurve(frameIndex, curveValues[0], curveValues[1], curveValues[2], curveValues[3]);
 		}

--- a/spinehaxe/animation/AnimationState.hx
+++ b/spinehaxe/animation/AnimationState.hx
@@ -163,7 +163,7 @@ class AnimationState {
 				var timelinesFirst:Array<Bool> = current.timelinesFirst;
 				for (ii in 0 ... timelineCount) {
 					var timeline:Timeline = timelines[ii];
-					if (Std.is(timeline, RotateTimeline)) {
+					if ((timeline is RotateTimeline)) {
 						applyRotateTimeline(timeline, skeleton, animationTime, mix, timelinesFirst[ii], timelinesRotation, ii << 1,
 							firstFrame);
 					} else
@@ -205,12 +205,12 @@ class AnimationState {
 		for (i in 0 ... timelineCount) {
 			var timeline:Timeline = timelines[i];
 			var setupPose:Bool = timelinesFirst[i];
-			if (Std.is(timeline, RotateTimeline))
+			if ((timeline is RotateTimeline))
 				applyRotateTimeline(timeline, skeleton, animationTime, alpha, setupPose, timelinesRotation, i << 1, firstFrame);
 			else {
 				if (!setupPose) {
-					if (!attachments && Std.is(timeline, AttachmentTimeline)) continue;
-					if (!drawOrder && Std.is(timeline, DrawOrderTimeline)) continue;
+					if (!attachments && (timeline is AttachmentTimeline)) continue;
+					if (!drawOrder && (timeline is DrawOrderTimeline)) continue;
 				}
 				timeline.apply(skeleton, animationLast, animationTime, events, alpha, setupPose, true);
 			}

--- a/spinehaxe/animation/DeformTimeline.hx
+++ b/spinehaxe/animation/DeformTimeline.hx
@@ -62,7 +62,7 @@ class DeformTimeline extends CurveTimeline {
 	override public function apply (skeleton:Skeleton, lastTime:Float, time:Float, firedEvents:Array<Event>, alpha:Float, setupPose:Bool, mixingOut:Bool):Void {
 		var slot:Slot = skeleton.slots[slotIndex];
 		var slotAttachment:Attachment = slot.attachment;
-		if (!Std.is(slotAttachment, VertexAttachment) || !(cast(slotAttachment, VertexAttachment).applyDeform(attachment))) return;
+		if (!(slotAttachment is VertexAttachment) || !(cast(slotAttachment, VertexAttachment).applyDeform(attachment))) return;
 
 		var verticesArray:Array<Float> = slot.attachmentVertices;
 		if (time < frames[0]) {

--- a/spinehaxe/platform/openfl/SkeletonSprite.hx
+++ b/spinehaxe/platform/openfl/SkeletonSprite.hx
@@ -83,7 +83,7 @@ class SkeletonSprite extends Sprite {
 				continue;
 			}
 
-			if (Std.is(slot.attachment, MeshAttachment))
+			if ((slot.attachment is MeshAttachment))
 			{
 				renderMeshes = true;
 				break;
@@ -152,7 +152,7 @@ class SkeletonSprite extends Sprite {
 		var drawOrder:Array<Slot> = skeleton.drawOrder;
 		for (i in 0 ... drawOrder.length) {
 			var slot:Slot = drawOrder[i];
-			if (slot.attachment == null || !Std.is(slot.attachment, RegionAttachment)) continue;
+			if (slot.attachment == null || !(slot.attachment is RegionAttachment)) continue;
 			var regionAttachment:RegionAttachment = cast slot.attachment;
 			if (regionAttachment != null) {
 				var wrapper:Sprite = regionAttachment.wrapper;
@@ -244,7 +244,7 @@ class SkeletonSprite extends Sprite {
 
 			if (slot.attachment != null)
 			{
-				if (Std.is(slot.attachment, RegionAttachment))
+				if ((slot.attachment is RegionAttachment))
 				{
 					var region:RegionAttachment = cast slot.attachment;
 					verticesLength = 8;
@@ -259,7 +259,7 @@ class SkeletonSprite extends Sprite {
 					b = region.b;
 					a = region.a;
 				}
-				else if (Std.is(slot.attachment, MeshAttachment))
+				else if ((slot.attachment is MeshAttachment))
 				{
 					var mesh:MeshAttachment = cast slot.attachment;
 					verticesLength = mesh.vertices.length;


### PR DESCRIPTION
`Std.is()` has been deprecated in Haxe 4.2: https://github.com/HaxeFoundation/haxe/commit/8ef3be1ae80fe4361572100fe7988518bc59c9ed

Rather than using `Std.isOfType()`, it's cleaner to use the `is` syntax with mandatory parens if possible - it's already available since Haxe 3.4, so it doesn't require conditional compilation (I doubt anybody is still using Haxe versions older than that).