### PR TITLE
remove enum deprecation warnings

### DIFF
--- a/spinehaxe/BlendMode.hx
+++ b/spinehaxe/BlendMode.hx
@@ -30,7 +30,7 @@
 
 package spinehaxe;
 
-@:enum
+#if haxe4 enum #else @:enum #end
 abstract BlendMode(String) from String to String {
 	var normal = "normal";
 	var additive = "additive";

--- a/spinehaxe/PositionMode.hx
+++ b/spinehaxe/PositionMode.hx
@@ -30,7 +30,7 @@
 
 package spinehaxe;
 
-@:enum
+#if haxe4 enum #else @:enum #end
 abstract PositionMode(String) from String to String {
 	var fixed = "fixed";
 	var percent = "percent";

--- a/spinehaxe/RotateMode.hx
+++ b/spinehaxe/RotateMode.hx
@@ -30,7 +30,7 @@
 
 package spinehaxe;
 
-@:enum
+#if haxe4 enum #else @:enum #end
 abstract RotateMode(String) from String to String {
 	var tangent = "tangent";
 	var chain = "chain";

--- a/spinehaxe/SpacingMode.hx
+++ b/spinehaxe/SpacingMode.hx
@@ -30,7 +30,7 @@
 
 package spinehaxe;
 
-@:enum
+#if haxe4 enum #else @:enum #end
 abstract SpacingMode(String) from String to String {
 	var length = "length";
 	var fixed = "fixed";

--- a/spinehaxe/TransformMode.hx
+++ b/spinehaxe/TransformMode.hx
@@ -30,7 +30,7 @@
 
 package spinehaxe;
 
-@:enum
+#if haxe4 enum #else @:enum #end
 abstract TransformMode(String) from String to String {
 	var normal = "normal";
 	var onlyTranslation = "onlytranslation";

--- a/spinehaxe/animation/EventType.hx
+++ b/spinehaxe/animation/EventType.hx
@@ -30,7 +30,7 @@
 
 package spinehaxe.animation;
 
-@:enum
+#if haxe4 enum #else @:enum #end
 abstract EventType(Int) {
 	var Start = 1;
 	var Interrupt = 2;

--- a/spinehaxe/animation/TimelineType.hx
+++ b/spinehaxe/animation/TimelineType.hx
@@ -30,7 +30,7 @@
 
 package spinehaxe.animation;
 
-@:enum
+#if haxe4 enum #else @:enum #end
 abstract TimelineType(Int) from Int to Int {
 	var rotate = 0;
 	var translate = 1;

--- a/spinehaxe/atlas/Format.hx
+++ b/spinehaxe/atlas/Format.hx
@@ -30,7 +30,7 @@
 
 package spinehaxe.atlas;
 
-@:enum
+#if haxe4 enum #else @:enum #end
 abstract Format(String) from String to String {
 	var Alpha = "alpha";
 	var Intensity = "intensity";

--- a/spinehaxe/atlas/TextureFilter.hx
+++ b/spinehaxe/atlas/TextureFilter.hx
@@ -30,7 +30,7 @@
 
 package spinehaxe.atlas;
 
-@:enum
+#if haxe4 enum #else @:enum #end
 abstract TextureFilter(String) from String to String {
 	var Nearest = "nearest";
 	var Linear = "linear";

--- a/spinehaxe/atlas/TextureWrap.hx
+++ b/spinehaxe/atlas/TextureWrap.hx
@@ -30,7 +30,7 @@
 
 package spinehaxe.atlas;
 
-@:enum
+#if haxe4 enum #else @:enum #end
 abstract TextureWrap(String) from String to String {
 	var MirroredRepeat = "mirroredRepeat";
 	var ClampToEdge = "clampToEdge";

--- a/spinehaxe/attachments/AttachmentType.hx
+++ b/spinehaxe/attachments/AttachmentType.hx
@@ -25,7 +25,7 @@
 
 package spinehaxe.attachments;
 
-@:enum
+#if haxe4 enum #else @:enum #end
 abstract AttachmentType(String) from String to String {
 	var Region = "region";
 	var RegionSequence = "regionsequence";


### PR DESCRIPTION
removes the various "@:enum is deprecated" warnings in haxe versions 4.3.1 and newer